### PR TITLE
fix bad relative paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,14 +3,15 @@
 var fs = require('fs');
 var path = require('path');
 
-var rulesFiles = fs.readdirSync('./lib/rules/');
+var rulesDir = path.join(__dirname, './lib/rules/');
+var rulesFiles = fs.readdirSync(rulesDir);
 
 // Generate an object of the form `{ ruleName: require('path/to/ruleFile.js'), ... }`
 // for use as the `rules` object of the exported object
 var rules = rulesFiles.reduce(function (aggregator, ruleFileName) {
   if (path.extname(ruleFileName) === '.js') {
     var ruleName = path.basename(ruleFileName, '.js');
-    aggregator[ruleName] = require('./lib/rules/' + ruleFileName);
+    aggregator[ruleName] = require(path.join(rulesDir, ruleFileName));
   }
 
   return aggregator;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -3,9 +3,11 @@ var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
 
-var rulesFiles = fs.readdirSync('./lib/rules/');
+var projectRoot = path.join(__dirname, '..');
 
-var myEslintConfig = require('../index');
+var rulesFiles = fs.readdirSync(path.join(projectRoot, './lib/rules/'));
+
+var myEslintConfig = require(path.join(projectRoot, './index'));
 
 describe('eslint-plugin-scanjs-rules', function () {
   it('should have a rule for each file in ./lib/rules', function () {


### PR DESCRIPTION
Added __dirname to path lookups to prevent errors trying to require rules

This causes a hard error when linting.