### PR TITLE
Fix JSON typo in scanjs-rules.json

### DIFF
--- a/lib/rules/scanjs-rules.json
+++ b/lib/rules/scanjs-rules.json
@@ -253,7 +253,7 @@
     "testhit": "sessionStorage.setItem('name', 'user1'); ",
     "testmiss": " 'sessionStorage'",
     "desc": "Client-side data storage.",
-    "threat": ""         p
+    "threat": ""
   },
   {
     "name": "Indexeddb",


### PR DESCRIPTION
ESLint is failing because of an unexpected "p" in the JSON.
This PR fixes it