### PR TITLE
Provide more context in `call_setTimeout`

### DIFF
--- a/lib/rules/call_setTimeout.js
+++ b/lib/rules/call_setTimeout.js
@@ -10,7 +10,7 @@ module.exports = function (context) {
   return {
     "CallExpression": function (node) {
       if ((node.callee.name == 'setTimeout') || ((node.callee.property) && (node.callee.property.name == 'setTimeout'))) {
-        context.report(node, "The function setTimeout can be unsafe");
+        context.report(node, "Calling setTimeout with a first argument as string (or string concatenation) with user input may lead to XSS");
       }
     }
   };


### PR DESCRIPTION
The [original rule that this seems to be based on](https://github.com/mozilla/scanjs/blob/master/common/rules.json#L35) has more context about _why_ `setTimeout` can be dangerous. This commit simply copy+pastes from the original scanjs rule to the eslint rule.